### PR TITLE
ek-tm4c123gxl.cfg is deprecated. replaced with ti_ek-tm4c123gxl.cfg

### DIFF
--- a/cmake/TivaCMake/FindOpenOCD.cmake
+++ b/cmake/TivaCMake/FindOpenOCD.cmake
@@ -37,7 +37,7 @@ The following cache variables may also be set:
 # on CMAKE_SYSTEM_PROCESSOR or (if set in the cache) the OpenOCD_BOARD variable
 # This is the configuration filename to search for when we try to find openocd configurations
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "TM4C123GH6PM")
-  set(OpenOCD_BOARD "ek-tm4c123gxl.cfg" CACHE STRING "The openocd configuration to use")
+  set(OpenOCD_BOARD "ti_ek-tm4c123gxl.cfg" CACHE STRING "The openocd configuration to use")
 endif()
 
 find_program(OpenOCD_EXECUTABLE openocd

--- a/lib/startup/stubs.c
+++ b/lib/startup/stubs.c
@@ -11,7 +11,7 @@
 #undef errno
 extern int errno;
 
-void _exit(int)
+void _exit(int placeholder)
 {
     // just abort everything
     __builtin_trap();
@@ -33,25 +33,25 @@ _sbrk (int incr)
    return (void *) prev_heap_end;
 }
 
-int _write(int, char*, int)
+int _write(int placeholder1, char* placeholder2, int placeholder3)
 {
     errno = ENOSYS;
     return -1;
 }
 
-int _close(int)
+int _close(int placeholder)
 {
     errno = ENOSYS;
     return -1;
 }
 
-int _read(int, char*, int)
+int _read(int placeholder1, char* placeholder2, int placeholder3)
 {
     errno = ENOSYS;
     return -1;
 }
 
-int _lseek(int, int, int)
+int _lseek(int placeholder1, int placeholder2, int placeholder3)
 {
     errno = ENOSYS;
     return -1;


### PR DESCRIPTION
when colcon build, it will give error otherwise